### PR TITLE
feat: add SuggestRemoteName to flatpakref

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -119,6 +119,9 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'automated')
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Enable auto-merge for PR
         run: |
           gh pr merge ${{ github.event.pull_request.number }} --squash --auto

--- a/com.windsurf.ide.metainfo.xml
+++ b/com.windsurf.ide.metainfo.xml
@@ -25,7 +25,7 @@
     <content_attribute id="social-info">moderate</content_attribute>
   </content_rating>
   <releases>
-    <release version="1.12.3" date="2025-08-29">
+    <release version="1.12.6" date="2025-09-17">
       <description>Latest stable release</description>
     </release>
   </releases>

--- a/com.windsurf.ide.yaml
+++ b/com.windsurf.ide.yaml
@@ -181,7 +181,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/flathub-infra/ide-flatpak-wrapper.git
-        commit: d581fd9b873acbf6fb22899aa388435f6c00f61a
+        commit: f8f6485adfe7df52db5f241e3a99f5c7540aff9f
       - type: file
         path: README.md
 

--- a/com.windsurf.ide.yaml
+++ b/com.windsurf.ide.yaml
@@ -114,9 +114,9 @@ modules:
       - type: extra-data
         filename: windsurf.tar.gz
         only-arches: [x86_64]
-        url: https://windsurf-stable.codeiumdata.com/linux-x64/stable/bfcd46e04becbf1670511e8c1e9cb0f1c1d62983/Windsurf-linux-x64-1.12.3.tar.gz
-        sha256: c9f0ea20d016b817f3d4ac2f66b9310f70f8d2d5c2314f56125ae9dc1c29d74d
-        size: 193149921
+        url: https://windsurf-stable.codeiumdata.com/linux-x64/stable/9a3d24f8ef44e756d945e890becee97bc90c6482/Windsurf-linux-x64-1.12.6.tar.gz
+        sha256: fed4da2979aac3978cca4ed493af5fa15489417f03072fd8c283855b223861be
+        size: 195180926
         x-checker-data:
           type: json
           url: https://windsurf-stable.codeium.com/api/update/linux-x64/stable/latest

--- a/scripts/pages_publisher_simple.py
+++ b/scripts/pages_publisher_simple.py
@@ -125,6 +125,7 @@ Title={app_info['title']}
 Name={app_info['name']}
 Url={base_url}/repo/
 RuntimeRepo=https://flathub.org/repo/flathub.flatpakrepo
+SuggestRemoteName=windsurf-origin
 GPGKey={public_key_b64}
 IsRuntime=false
 """


### PR DESCRIPTION
Add SuggestRemoteName=windsurf-origin field to the generated flatpakref file to provide users with a suggested remote name when installing the Flatpak.

This change will improve the user experience by giving the remote repository a meaningful name instead of a generic one.