### PR TITLE
Update Windsurf to 1.13.3

### DIFF
--- a/com.windsurf.ide.metainfo.xml
+++ b/com.windsurf.ide.metainfo.xml
@@ -25,7 +25,7 @@
     <content_attribute id="social-info">moderate</content_attribute>
   </content_rating>
   <releases>
-    <release version="1.12.6" date="2025-09-17">
+    <release version="1.13.3" date="2025-12-26">
       <description>Latest stable release</description>
     </release>
   </releases>

--- a/com.windsurf.ide.yaml
+++ b/com.windsurf.ide.yaml
@@ -114,9 +114,9 @@ modules:
       - type: extra-data
         filename: windsurf.tar.gz
         only-arches: [x86_64]
-        url: https://windsurf-stable.codeiumdata.com/linux-x64/stable/9a3d24f8ef44e756d945e890becee97bc90c6482/Windsurf-linux-x64-1.12.6.tar.gz
-        sha256: fed4da2979aac3978cca4ed493af5fa15489417f03072fd8c283855b223861be
-        size: 195180926
+        url: https://windsurf-stable.codeiumdata.com/linux-x64/stable/f5d6162bf21a6caf7ad124c0ddf9cb1089034608/Windsurf-linux-x64-1.13.3.tar.gz
+        sha256: f99695a40775b275d9e09dd5ce9d56d3a15c98ad58804e40e4c8a6dc060926cc
+        size: 228962296
         x-checker-data:
           type: json
           url: https://windsurf-stable.codeium.com/api/update/linux-x64/stable/latest


### PR DESCRIPTION
## Windsurf Version Update

**Current Version:** `1.12.6`
**New Version:** `1.13.3`

### Changes
- Updated Windsurf binary URL to: `https://windsurf-stable.codeiumdata.com/linux-x64/stable/f5d6162bf21a6caf7ad124c0ddf9cb1089034608/Windsurf-linux-x64-1.13.3.tar.gz`
- Updated SHA256: `f99695a40775b275d9e09dd5ce9d56d3a15c98ad58804e40e4c8a6dc060926cc`
- Updated file size: `228,962,296 bytes`
- Updated metainfo.xml with new version and current date

### Automation
This PR was created automatically by the Windsurf update bot.
- ✅ Auto-merge enabled - will merge when required status checks pass
- 🏗️ Flatpak build will be tested automatically
- 🔄 Will merge automatically if all checks pass

---
*Generated by Windsurf Flatpak automation*